### PR TITLE
Show most recent repositories, Fixes #7

### DIFF
--- a/app/components/addRepository/add.repository.component.html
+++ b/app/components/addRepository/add.repository.component.html
@@ -60,7 +60,11 @@
 	        </div>
 	
       </div>
-      <div id="testing" (load)="loadMostRecentRepos()">    
+      <!-- TODO: Jamie and Srishti please use this div to show list of elements. You are probably going to use
+      *ngif to display the list of repos? -->
+      <div (load)="loadMostRecentRepos()"> 
+        <div (window:loadRecentRepos)="updateRepos($event)"></div> 
+        <!-- <button class="button-open" id = "testButton" (click)="loadMostRecentRepos()">Refresh List</button> -->
 	    </div>
   </div>
 </div>

--- a/app/components/addRepository/add.repository.component.html
+++ b/app/components/addRepository/add.repository.component.html
@@ -42,29 +42,30 @@
         </div>
       </div>
     </div>
-    
     <div id="create-local-repository">
 	      <div class="title">
 	        <h1>Create a local repository</h1>
 	      </div>
-	
 	      <div class="block">
 	        <div class="left">
 	          <p>Location of folder</p>
 	        </div>
-	
 	        <div class="right">
 	          <input type="text" name="folderLocal" class = "path-textbox" id="repoCreate"/>
 	          <button class="button-open" (click)="selectLocalRepoDirectory()">Create</button>
 	          <input type="file" id="dirPickerCreateLocal" name="localDir" (change)="createLocalRepository()" style="display: none;" webkitdirectory />
 	        </div>
-	
+        </div>
+    </div>
+    <div id="recent-repository" *ngIf="showRecent" (load)="loadMostRecentRepos()"> 
+      <div class="title"><h1>Recent Repositories</h1></div>
+      <div class="block" (window:loadRecentRepos)="updateRepos($event)">
+        <div class="left">&nbsp;</div>
+        <div class="right">
+          <ul>
+            <li *ngFor="let repo of recentRepos; let i = index" [attr.data-index]="i"><button class="btn btn-default" (click)="openRecentRepository(repo)"><span class="badge">{{  i + 1 }}</span>{{ repo }}</button></li>
+          </ul>
+        </div>
       </div>
-      <!-- TODO: Jamie and Srishti please use this div to show list of elements. You are probably going to use
-      *ngif to display the list of repos? -->
-      <div (load)="loadMostRecentRepos()"> 
-        <div (window:loadRecentRepos)="updateRepos($event)"></div> 
-        <!-- <button class="button-open" id = "testButton" (click)="loadMostRecentRepos()">Refresh List</button> -->
-	    </div>
-  </div>
+    </div>
 </div>

--- a/app/components/addRepository/add.repository.component.html
+++ b/app/components/addRepository/add.repository.component.html
@@ -59,6 +59,8 @@
 	          <input type="file" id="dirPickerCreateLocal" name="localDir" (change)="createLocalRepository()" style="display: none;" webkitdirectory />
 	        </div>
 	
+      </div>
+      <div id="testing" (load)="loadMostRecentRepos()">    
 	    </div>
   </div>
 </div>

--- a/app/components/addRepository/add.repository.component.ts
+++ b/app/components/addRepository/add.repository.component.ts
@@ -9,10 +9,9 @@ export class AddRepositoryComponent {
   recentRepos: [];
   loadMostRecentRepos:any;
   showRecent: boolean;
+
   ngOnInit(): void {
-   
-    //TODO: Jamie and Srishti need to display the returned list from loadMostRecentRepos() in the front end
-    // TODO: remove console.logs before final push 
+    // Show list of recent repos in order by most recently opened
     this.recentRepos = loadMostRecentRepos();
     this.recentRepos.reverse()
     if(this.recentRepos.length >0){
@@ -20,9 +19,7 @@ export class AddRepositoryComponent {
     }
   }
 
-  //TODO: Jamie and Srishti need to display the returned list from loadMostRecentRepos() in the front end 
-  // TODO: remove console.logs before final push 
-  // Custom event listener that is called 
+  // Custom event listener that is called whenever addRepository component is displayed
   @HostListener('window:loadRecentRepos', ['$event']) 
   updateRepos(event) {
     this.recentRepos = loadMostRecentRepos();
@@ -32,6 +29,7 @@ export class AddRepositoryComponent {
     }
   }
 
+  // Open user selected recently opened repo 
   openRecentRepository(repo): void {
     console.log(repo);
     (<HTMLInputElement>document.getElementById("repoOpen")).value = repo;

--- a/app/components/addRepository/add.repository.component.ts
+++ b/app/components/addRepository/add.repository.component.ts
@@ -1,4 +1,4 @@
-import { Component } from "@angular/core";
+import { Component, HostListener } from "@angular/core";
 declare let loadMostRecentRepos:any;
 @Component({
   selector: "add-repository-panel",
@@ -9,13 +9,30 @@ export class AddRepositoryComponent {
   recentRepos: [];
   loadMostRecentRepos:any;
   ngOnInit(): void {
+   
+    //TODO: Jamie and Srishti need to display the returned list from loadMostRecentRepos() in the front end
+    // TODO: remove console.logs before final push 
     console.log('test');
-    TODO: Jamie and Srishti need to display the returned list from loadMostRecentRepos() in the front end 
     this.recentRepos = loadMostRecentRepos();
     console.log(this.recentRepos);
   }
 
-    
+  //TODO: Jamie and Srishti need to display the returned list from loadMostRecentRepos() in the front end 
+  // TODO: remove console.logs before final push 
+  // Custom event listener that is called 
+  @HostListener('window:loadRecentRepos', ['$event']) 
+  updateRepos(event) {
+    console.log(this.recentRepos);
+    this.recentRepos = loadMostRecentRepos();
+    console.log(this.recentRepos);
+  }
+
+  // loadMostRecentRepos(): void {
+  //   console.log(this.recentRepos);
+  //   this.recentRepos = loadMostRecentRepos();
+  //   console.log(this.recentRepos);
+  // }
+  
   
   selectClone(): void {
     if (document.getElementById("repoClone").value == null || document.getElementById("repoClone").value == "") {

--- a/app/components/addRepository/add.repository.component.ts
+++ b/app/components/addRepository/add.repository.component.ts
@@ -1,13 +1,22 @@
 import { Component } from "@angular/core";
-
+declare let loadMostRecentRepos:any;
 @Component({
   selector: "add-repository-panel",
   templateUrl: 'app/components/addRepository/add.repository.component.html'
 })
 
 export class AddRepositoryComponent {
+  recentRepos: [];
+  loadMostRecentRepos:any;
+  ngOnInit(): void {
+    console.log('test');
+    TODO: Jamie and Srishti need to display the returned list from loadMostRecentRepos() in the front end 
+    this.recentRepos = loadMostRecentRepos();
+    console.log(this.recentRepos);
+  }
 
-
+    
+  
   selectClone(): void {
     if (document.getElementById("repoClone").value == null || document.getElementById("repoClone").value == "") {
       window.alert("Please enter the URL of the repository you wish to clone");
@@ -64,6 +73,8 @@ export class AddRepositoryComponent {
   returnToMainPanel(): void {
     switchToMainPanel();
   }
+
+
   prepareDontMissDND :  function() {
 
       $(document.body).bind("dragover", function(e) {
@@ -76,6 +87,9 @@ export class AddRepositoryComponent {
           fileUpload(e);
           return false;
       });
+
+
+  
 }
 
 function fileUpload(ev){

--- a/app/components/addRepository/add.repository.component.ts
+++ b/app/components/addRepository/add.repository.component.ts
@@ -8,13 +8,15 @@ declare let loadMostRecentRepos:any;
 export class AddRepositoryComponent {
   recentRepos: [];
   loadMostRecentRepos:any;
+  showRecent: boolean;
   ngOnInit(): void {
    
     //TODO: Jamie and Srishti need to display the returned list from loadMostRecentRepos() in the front end
     // TODO: remove console.logs before final push 
-    console.log('test');
     this.recentRepos = loadMostRecentRepos();
-    console.log(this.recentRepos);
+    if(this.recentRepos.length >0){
+      this.showRecent = true
+    }
   }
 
   //TODO: Jamie and Srishti need to display the returned list from loadMostRecentRepos() in the front end 
@@ -22,17 +24,18 @@ export class AddRepositoryComponent {
   // Custom event listener that is called 
   @HostListener('window:loadRecentRepos', ['$event']) 
   updateRepos(event) {
-    console.log(this.recentRepos);
     this.recentRepos = loadMostRecentRepos();
-    console.log(this.recentRepos);
+    if(this.recentRepos.length >0){
+      this.showRecent = true
+    }
   }
 
-  // loadMostRecentRepos(): void {
-  //   console.log(this.recentRepos);
-  //   this.recentRepos = loadMostRecentRepos();
-  //   console.log(this.recentRepos);
-  // }
-  
+  openRecentRepository(repo): void {
+    console.log(repo);
+    (<HTMLInputElement>document.getElementById("repoOpen")).value = repo;
+    openRepository();
+    switchToMainPanel();
+  }
   
   selectClone(): void {
     if (document.getElementById("repoClone").value == null || document.getElementById("repoClone").value == "") {

--- a/app/components/addRepository/add.repository.component.ts
+++ b/app/components/addRepository/add.repository.component.ts
@@ -14,6 +14,7 @@ export class AddRepositoryComponent {
     //TODO: Jamie and Srishti need to display the returned list from loadMostRecentRepos() in the front end
     // TODO: remove console.logs before final push 
     this.recentRepos = loadMostRecentRepos();
+    this.recentRepos.reverse()
     if(this.recentRepos.length >0){
       this.showRecent = true
     }
@@ -25,6 +26,7 @@ export class AddRepositoryComponent {
   @HostListener('window:loadRecentRepos', ['$event']) 
   updateRepos(event) {
     this.recentRepos = loadMostRecentRepos();
+    this.recentRepos.reverse()
     if(this.recentRepos.length >0){
       this.showRecent = true
     }

--- a/app/components/app/app.component.ts
+++ b/app/components/app/app.component.ts
@@ -10,6 +10,7 @@ import { WikiComponent } from "../wiki/wiki.component";
 import {selectedCommitDiffPanelComponent} from "../selectedCommitDiffPanel/selected.commit.diff.panel.component";
 import { IssuePanelComponent } from "../issuePanel/issue.panel.component";
 import { PullRequestPanelComponent } from "../pullRequestPanel/pull.request.panel.component";
+declare let createSettingsDir:any;
 
 @Component({
   selector: "my-app",
@@ -18,6 +19,8 @@ import { PullRequestPanelComponent } from "../pullRequestPanel/pull.request.pane
 })
 
 export class AppComponent {
+  createSettingsDir:any;
+
   ngOnInit(): void {
     const userColorFilePath = ".settings/user_color.txt";
 
@@ -28,6 +31,11 @@ export class AppComponent {
         let color = buffer.toString();
         changeColor(color);
       });
+      
     }
+    createSettingsDir();
+
   }
+
+
 }

--- a/app/misc/router.ts
+++ b/app/misc/router.ts
@@ -71,8 +71,7 @@ function switchToAddRepositoryPanelWhenNotSignedIn() {
 }
 
 function switchToAddRepositoryPanel() {
-  
-  // document.getElementById("testButton").click();
+
   window.dispatchEvent(new Event('loadRecentRepos'));
 
   document.getElementById("Button_Sign_out").style.display = "block";

--- a/app/misc/router.ts
+++ b/app/misc/router.ts
@@ -71,6 +71,11 @@ function switchToAddRepositoryPanelWhenNotSignedIn() {
 }
 
 function switchToAddRepositoryPanel() {
+  
+  // document.getElementById("testButton").click();
+  window.dispatchEvent(new Event('loadRecentRepos'));
+
+  document.getElementById("Button_Sign_out").style.display = "block";
   inTheApp = true
   console.log("Switching to add repo panel");
   hideAuthenticatePanel();

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -401,6 +401,7 @@ body .add-repository-panel .path-textbox {
   float:left;
   border-radius: 7px;
   box-shadow: 2px 2px 2px white;
+  white-space: normal;
 }
 
 #recent-repository ul {

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -361,22 +361,52 @@ body .add-repository-panel input {
 }
 
 body .add-repository-panel .button-clone, body .add-repository-panel .button-open {
-  display: inline-block;
+  /*display: inline-block;*/
   height: 30px;
-  border-radius: 10px;
+  border-radius: 7px;
   border: 0;
   padding: 0 15px;
-  margin: 15px 40px;
-  margin-left: 10px;
+  margin: 12px 40px;
+  /* margin-left: 10px; */
   background-color: #39c0ba;
   color: #fff;
   float: right;
+  font-weight:bold;
+  width:150px;
+  text-shadow: 1px 1px 1px black;
+  box-shadow: 1px 1px 1px #39c0ba;
 }
 
 body .add-repository-panel .path-textbox {
   width: 50%;
   min-width: 10%;
+  height:20%;
+  font-size:15px;
+  border-radius: 7px;
+  padding:5px;
+  box-shadow: 1px 1px 1px white;
 }
+
+#recent-repository span {
+  font-size:10px;
+  float:left;
+  box-shadow: 1px 1px 1px black;
+  margin:2px;
+}
+
+#recent-repository button {
+  width:50%; 
+  margin: 4px 30px;
+  padding:2px;
+  float:left;
+  border-radius: 7px;
+  box-shadow: 2px 2px 2px white;
+}
+
+#recent-repository ul {
+  padding: 0;
+}
+
 
 body .add-repository-panel .button-clone:hover, body .add-repository-panel .button-open:hover {
   opacity: 0.8;
@@ -384,6 +414,7 @@ body .add-repository-panel .button-clone:hover, body .add-repository-panel .butt
 
 body .add-repository-panel .title {
   width: 100%;
+  text-shadow: .5px .5px .5px white;
 }
 
 body .add-repository-panel .title .clone-title {
@@ -398,6 +429,7 @@ body .add-repository-panel .block {
 body .add-repository-panel .block p {
   display: inline-block;
   margin: 15px 0px;
+  font-size: 15px
 }
 
 body .add-repository-panel .left {

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -391,7 +391,7 @@ body .add-repository-panel .path-textbox {
   font-size:10px;
   float:left;
   box-shadow: 1px 1px 1px black;
-  margin:2px;
+  margin:2px 6px 2px 2px
 }
 
 #recent-repository button {
@@ -401,6 +401,9 @@ body .add-repository-panel .path-textbox {
   float:left;
   border-radius: 7px;
   box-shadow: 2px 2px 2px white;
+  text-align: left;
+  white-space: normal;
+  font-size: 14px;
 }
 
 #recent-repository ul {


### PR DESCRIPTION
We have implemented a new feature which shows the user's most recent opened repositories

<img width="1264" alt="Screen Shot 1440-09-21 at 7 09 32 PM" src="https://user-images.githubusercontent.com/39515277/58391467-e86c5780-7fea-11e9-9105-1d36391286b0.png">

Every time a user opens a new repository, the system appends opened repo path into recent_repos.json file. If recent_repos.json does not exist, it gets created before appending repo path. 

