### PR TITLE
Fix Issue #8: Making a commit through visual git does not cause the graph to update

### DIFF
--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -58,7 +58,7 @@ function sortedListOfCommits(commits){
       }
     }
   }
-  
+
 }
 
 function cloneFromRemote() {
@@ -204,7 +204,7 @@ function addAndCommit() {
       hideDiffPanel();
       clearStagedFilesList();
       clearCommitMessage();
-      clearSelectAllCheckbox();
+      //clearSelectAllCheckbox();
       for (let i = 0; i < filesToAdd.length; i++) {
         addCommand("git add " + filesToAdd[i]);
       }
@@ -375,7 +375,7 @@ function pullFromRemote() {
       if (conflicsExist) {
         let conflictedFiles = tid.split("Conflicts:")[1];
         refreshAll(repository);
-       
+
         window.alert("Conflicts exists! Please check the following files:" + conflictedFiles +
          "\n Solve conflicts before you commit again!");
       } else {
@@ -738,7 +738,7 @@ function revertCommit() {
     sortedListOfCommits(Commits);
      console.log("Commits; "+ commitHistory[0]);
     })
-    
+
     Git.Repository.open(repoFullPath)
     .then(function(repo){
       repos = repo;
@@ -755,7 +755,7 @@ function revertCommit() {
     if(commitHistory[index].parents().length > 1) {
       revertOptions.mainline = 1;
     }
-    
+
     revertOptions.mergeInMenu = 1;
     return Git.Revert.revert(repos, commitHistory[index],revertOptions)
     .then(function(number) {
@@ -816,7 +816,7 @@ function displayModifiedFiles() {
         }
 
         modifiedFiles.forEach(displayModifiedFile);
-        
+
         removeNonExistingFiles();
         refreshColor();
 
@@ -1261,7 +1261,7 @@ function cleanRepo() {
 }
 
 /**
- * This method is called when the sync button is pressed, and causes the fetch-modal 
+ * This method is called when the sync button is pressed, and causes the fetch-modal
  * to appear on the screen.
  */
 function requestLinkModal() {
@@ -1269,7 +1269,7 @@ function requestLinkModal() {
 }
 
 /**
- * This method is called when a valid URL is given via the fetch-modal, and runs the 
+ * This method is called when a valid URL is given via the fetch-modal, and runs the
  * series of git commands which fetch and merge from an upstream repository.
  */
 function fetchFromOrigin() {

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -204,6 +204,13 @@ function addAndCommit() {
       hideDiffPanel();
       clearStagedFilesList();
       clearCommitMessage();
+      /*
+        Issue 8: Making a commit through visual git does not cause the graph to update
+        'addAndCommit' function was not reaching beyond this point therefore 'refreshAll(repository)'
+        was not able to update the graph and labels for the new commit. It is believed that the functionality
+        of a 'SelectAllCheckbox' was either removed or has yet to be implemented. Commenting out this function fixes the issue.
+        A new issue will be opened such that we may implement this feature. -mdesco18
+      */
       //clearSelectAllCheckbox();
       for (let i = 0; i < filesToAdd.length; i++) {
         addCommand("git add " + filesToAdd[i]);

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -261,10 +261,10 @@ function clearModifiedFilesList() {
 function clearCommitMessage() {
   document.getElementById('commit-message-input').value = "";
 }
-
+/* See line 207 for details
 function clearSelectAllCheckbox() {
   document.getElementById('select-all-checkbox').checked = false;
-}
+}*/
 
 function getAllCommits(callback) {
   clearModifiedFilesList();

--- a/test_file.txt
+++ b/test_file.txt
@@ -1,0 +1,1 @@
+test commits

--- a/test_file.txt
+++ b/test_file.txt
@@ -1,1 +1,2 @@
 test commits
+test if commit remains local

--- a/test_file.txt
+++ b/test_file.txt
@@ -1,2 +1,3 @@
 test commits
 test if commit remains local
+test2

--- a/test_file.txt
+++ b/test_file.txt
@@ -1,3 +1,0 @@
-test commits
-test if commit remains local
-test2


### PR DESCRIPTION
Commented out the function clearSelectAllCheckbox within the function addAndCommit in git.ts that prevented the graph to be reloaded with the new commit.  The removal of the former function is justified to fix the issue as a 'Select All' checkbox has yet to be implemented in the GUI. 