### PR TITLE
Fix Issue #31: Prevent craching when clicking push before commiting

### DIFF
--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -386,6 +386,10 @@ function pullFromRemote() {
 }
 
 function pushToRemote() {
+    if (CommitButNoPush === 0) {
+        window.alert("Cannot push without a commit.");
+        return;
+    }
   let branch = document.getElementById("branch-name").innerText;
   Git.Repository.open(repoFullPath)
     .then(function (repo) {


### PR DESCRIPTION
## PR fixes 
1. crashing when clicking push before commiting by checking to see if there are any unpushed commits 
2. Notifying the user to commit before pushing.

## Issue discovered
- There is an issue where the app crashes if you commit->push->commit->push
