### PR TITLE
Fix Issue #11: Prevent app from reloading when pressing F5 when window is blurred

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ function setMyMenu() {
 
 function registerF5() {
 	// disable the F5 key from reloading the app (caused by electron-debug)
-	globalShortcut.register('F5', function(){});
+	globalShortcut.register('F5', () => {});
 }
 
 app.on('window-all-closed', () => {

--- a/index.js
+++ b/index.js
@@ -170,6 +170,11 @@ function setMyMenu() {
 	return myMenu;
 }
 
+function registerF5() {
+	// disable the F5 key from reloading the app (caused by electron-debug)
+	globalShortcut.register('F5', function(){});
+}
+
 app.on('window-all-closed', () => {
 	if (process.platform !== 'darwin') {
 		app.quit();
@@ -182,9 +187,12 @@ app.on('activate', () => {
 	}
 });
 
+app.on('browser-window-blur', () => {
+	registerF5();
+});
+
 app.on('ready', () => {
 	mainWindow = createMainWindow();
 	Menu.setApplicationMenu(Menu.buildFromTemplate(setMyMenu()));
-	// disable the F5 key from reloading the app (caused by electron-debug)
-	globalShortcut.register('F5', function(){});
+	registerF5();
 });


### PR DESCRIPTION
The F5 key was disabled in PR https://github.com/uvicgse/project-virtual-team-2/pull/49, but it was reverted to normal when the application window was blurred (unfocused). To maintain disabling, I ran the `registerF5` function using Electron's app API `'browser-window-blur'` event. 