### PR TITLE
Fix Issue #65: Unstaged Files not displaying on Mac

### DIFF
--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -836,7 +836,7 @@ function displayModifiedFiles() {
           let filePaths = document.getElementsByClassName('file-path');
           for (let i = 0; i < filePaths.length; i++) {
             if (filePaths[i].parentElement.className !== "file file-deleted") {
-              let filePath = repoFullPath + "\\" + filePaths[i].innerHTML;
+              let filePath = path.join(repoFullPath, filePaths[i].innerHTML); //modified for *NIX users
               if (!fs.existsSync(filePath)) {
                 filePaths[i].parentElement.remove();
               }
@@ -1244,7 +1244,7 @@ function cleanRepo() {
 
         //Gets NEW/untracked files and deletes them
         function deleteUntrackedFiles(file) {
-          let filePath = repoFullPath + "\\" + file.path();
+          let filePath = path.join(repoFullpath, file.path()); //modified for *NIX users
           let modification = calculateModification(file);
           if (modification === "NEW") {
             console.log("DELETING FILE " + filePath);


### PR DESCRIPTION
As mentioned by team 1 and as seen in team 2's demo, files flicker or do not show when in the displayModifiedFiles modal on Mac. To find this, doing a ctrl+F in the relevant files for '\\' showed paths that were Windows specific. To fix this, I replaced the string paths that include '\\' with a function to join the paths of the files and the repo. I am on Windows and have not tested on Mac yet. 