### PR TITLE
Fixed Issue #3: file editor overflows

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -491,7 +491,7 @@ body .footer .commit-panel .commit-message-input {
 }
 
 body .footer .commit-panel .commit-button-wrapper {
-  /* positioned relative to its normal position */
+  /* positioned relative to its normal position(bottom left corner) */
   position: relative;
   display: flex;
   justify-content: center;
@@ -505,10 +505,8 @@ body .footer .commit-panel .commit-button-wrapper .commit-button {
   white-space: pre-line;
   position: static;
   display: block;
-  margin-left: 8px;
-  margin-right: 8px;
-  margin-top: 8px;
-  margin-bottom: 8px;
+  margin: 8px;
+  
   height: 40px;
   border-radius: 10px;
   border: 0;

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -491,26 +491,28 @@ body .footer .commit-panel .commit-message-input {
 }
 
 body .footer .commit-panel .commit-button-wrapper {
+  position: relative;
   display: flex;
   justify-content: center;
   align-items: center;
-  position: relative;
+
   border: 0;
 }
 
 body .footer .commit-panel .commit-button-wrapper .commit-button {
   display: block;
-  margin-left: 10px;
-  margin-right: 10px;
-  margin-top: 10px;
-  margin-bottom: 10px;
-  height: 30px;
+  margin-left: 8px;
+  margin-right: 8px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+  height: 40px;
   border-radius: 10px;
   border: 0;
   padding: 0 15px;
   background-color: #39c0ba;
   color: #fff;
-  white-space: nowrap;
+  white-space: pre-line;
+  position: static;
 }
 
 body .footer .commit-panel .commit-button:hover {

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -494,6 +494,8 @@ body .footer .commit-panel .commit-button-wrapper {
   display: flex;
   justify-content: center;
   align-items: center;
+  position: relative;
+  border: 0;
 }
 
 body .footer .commit-panel .commit-button-wrapper .commit-button {
@@ -508,6 +510,7 @@ body .footer .commit-panel .commit-button-wrapper .commit-button {
   padding: 0 15px;
   background-color: #39c0ba;
   color: #fff;
+  white-space: nowrap;
 }
 
 body .footer .commit-panel .commit-button:hover {

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -491,6 +491,7 @@ body .footer .commit-panel .commit-message-input {
 }
 
 body .footer .commit-panel .commit-button-wrapper {
+  /* positioned relative to its normal position */
   position: relative;
   display: flex;
   justify-content: center;
@@ -500,6 +501,9 @@ body .footer .commit-panel .commit-button-wrapper {
 }
 
 body .footer .commit-panel .commit-button-wrapper .commit-button {
+  /*sequences of white space are collapsed and lines are broken at newline characters*/
+  white-space: pre-line;
+  position: static;
   display: block;
   margin-left: 8px;
   margin-right: 8px;
@@ -511,8 +515,6 @@ body .footer .commit-panel .commit-button-wrapper .commit-button {
   padding: 0 15px;
   background-color: #39c0ba;
   color: #fff;
-  white-space: pre-line;
-  position: static;
 }
 
 body .footer .commit-panel .commit-button:hover {


### PR DESCRIPTION
Fixed issue #3 by collapsing sequences of white space which makes lines break at newline characters. Also, fixed the alignment of the buttons by adding 10 more pixels to the hight and subtracting 2 pixels from the margins.