### PR TITLE
Fix issue where create commit requires a tag name

### DIFF
--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -408,7 +408,12 @@ function addAndCommit() {
       console.log("Commit successful: " + oid.tostrS());
       stagedFiles = null;
       console.log(oid.tostrS());
-      return repository.createTag(oid.tostrS(), tagName, tagMessage);
+      // Create tag if tag name is not empty
+      if (tagName != "") {
+        return repository.createTag(oid.tostrS(), tagName, tagMessage);
+      } else {
+        return 
+      }
     })
     // will update user interface after new commit and tag has been handled
     .then(function (tag: any) {


### PR DESCRIPTION
This pull request is meant to resolve the bug where a user must provide a tag name in order to create a commit. The code changes in this pull request will ensure a user is able to create a commit with just a commit message and added files. 