### PR TITLE
Improve stash drop CSS fixes

### DIFF
--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -229,11 +229,10 @@ function refreshStashHistory(){
     // For each stash create a unique element with unique pop, drop, and apply functionality.
     stashHistory.forEach((stash, i) => {
       stashListHTML +=
-        '<div id="stash-item">' +
-          '<div id="stash-id">' +
-
+        '<div class="stash-item">' +
+          '<span class="stash-name">' +
               'Stash{' + i + '}: ' + stash +
-          '</div>' +
+          '</span>' +
           '<div class="stash-actions">' +
               '<ul class="dropbtn icons" onclick="showDropdown(' + i + ')">' +
                   '<li></li>' +
@@ -242,11 +241,11 @@ function refreshStashHistory(){
               '</ul>' +
 
               '<div id="stash-item-' + i + '-dropdown" class="dropdown-content">' +
-                  '<a onclick="popStash(' + i + ')">Pop</a>' +
-                  '<a onclick="applyStash(' + i + ')">Apply</a>' +
-                  '<a onclick="dropStash(' + i + ')">Drop</a>' +
-                  '<a onclick="showStash(' + i + ')">Show</a>' +
-                  '<a onclick="openBranchModal('+i+')">Branch<\a>' +
+                  '<a data-dismiss="modal" onclick="popStash(' + i + ')">Pop</a>' +
+                  '<a data-dismiss="modal" onclick="applyStash(' + i + ')">Apply</a>' +
+                  '<a data-dismiss="modal" onclick="dropStash(' + i + ')">Drop</a>' +
+                  '<a data-dismiss="modal" onclick="showStash(' + i + ')">Show</a>' +
+                  '<a data-dismiss="modal" onclick="openBranchModal('+i+')">Branch</a>' +
               '</div>' +
           '</div>' +
         '</div>';

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -1217,7 +1217,7 @@ body .pull-request-panel {
   margin-left: 10px;
 }
 
-#stash-item {
+.stash-item {
   display: inline-flex;
   align-items: center;
   background: #efefef;
@@ -1226,7 +1226,7 @@ body .pull-request-panel {
   width: 100%;
 }
 
-#stash-id {
+.stash-name {
   width: 100%;
 }
 
@@ -1251,6 +1251,7 @@ body .pull-request-panel {
     margin-top: auto;
     margin-right: auto;
     margin-bottom: auto;
+    padding: 8px;
 }
 
 .dropdown {
@@ -1275,7 +1276,10 @@ body .pull-request-panel {
     display: block;
 }
 
-.dropdown a:hover {background-color: #f1f1f1}
+.dropdown-content a:hover {
+  background-color: #efefef;
+  cursor: pointer;
+}
 
 .show {display:block;}
 /* stash-item dropdown menu styles END */


### PR DESCRIPTION
Changes you will see:
- Stash list items with index > 0 now do not show up as anchors
- Increased padding on dropdown menu
- Dropdown menu's colour on hover is now being applied
- Dropdown menu items now have 'cursor: pointer' being applied to them
- Modal now closes when stash operations are applied