### PR TITLE
Revert "Implemented: Fix to #34"

### DIFF
--- a/app/components/footer/footer.component.css
+++ b/app/components/footer/footer.component.css
@@ -1,0 +1,10 @@
+.commit-input-button-wrapper { 
+    margin-left:10px; 
+}
+
+.modal-body-input {
+    border-radius: 3px;
+    padding: 4px;
+    margin: 16px;
+    width: 60%;
+  }

--- a/app/components/footer/footer.component.html
+++ b/app/components/footer/footer.component.html
@@ -5,9 +5,14 @@
                 <textarea placeholder="Describe your tag message (Optional)..." class="tag-message-input" id="tag-message-input"></textarea>
         </div>
         
-        <textarea placeholder="Describe your changes here..." class="commit-message-input" id="commit-message-input"></textarea>
+       
         <div class="commit-button-wrapper" id="commit-button-wrapper">
-            <button class="commit-button" id="commit-button">Commit</button>
+            <textarea style="width:70%"placeholder="Describe your changes here..." class="commit-message-input" id="commit-message-input"></textarea>
+          <button class="commit-button" id="commit-button">Commit</button>
+        </div>
+        
+        <div class="commit-button-wrapper" id="commit-button-wrapper">
+            
             <button class="commit-button" id="fileEdit-button" (click)="displayFileEditor()">File Editor</button>
             <button class="commit-button" id="Issues-button" (click)="displayIssuePanel()">Issues</button>
             <!-- Maybe style this better -->

--- a/app/components/footer/footer.component.html
+++ b/app/components/footer/footer.component.html
@@ -10,7 +10,8 @@
             <button class="commit-button" id="commit-button">Commit</button>
             <button class="commit-button" id="fileEdit-button" (click)="displayFileEditor()">File Editor</button>
             <button class="commit-button" id="Issues-button" (click)="displayIssuePanel()">Issues</button>
-            <button class="commit-button" id="amend-commit-button" (click)="amendLastCommit()" >Amend Commit</button>
+            <!-- Maybe style this better -->
+            <button class="commit-button" id="amend-commit-button" data-toggle="modal" data-target="#amend-commit-modal">Amend Commit</button>
 
         </div>
     </div>
@@ -26,3 +27,25 @@
         </div>
     </div>
 </div>
+<!-- TODO: Modify style of modal and add ability to handle user input-->
+<!--Modal for amending the last commit-->
+<div id="amend-commit-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+          <h4 class="modal-title">Amend Last Local Commit</h4>
+        </div>
+        <div class="modal-body">
+          <div>
+            <button type="button" class="btn btn-primary" (click)="amendLastCommit()" data-dismiss="modal">Amend</button>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/app/components/footer/footer.component.html
+++ b/app/components/footer/footer.component.html
@@ -6,8 +6,8 @@
         </div>
         
        
-        <div class="commit-button-wrapper" id="commit-button-wrapper">
-            <textarea style="width:70%"placeholder="Describe your changes here..." class="commit-message-input" id="commit-message-input"></textarea>
+        <div class="commit-button-wrapper commit-input-button-wrapper" id="commit-button-wrapper">
+          <textarea placeholder="Describe your changes here..." class="commit-message-input" id="commit-message-input"></textarea>
           <button class="commit-button" id="commit-button">Commit</button>
         </div>
         
@@ -45,9 +45,9 @@
         </div>
         <div class="modal-body">
           <div>
-            <button type="button" class="btn btn-primary" (click)="amendLastCommit(amend)" data-dismiss="modal">Amend</button>
             <!-- Here's the input field to add the modified commit message -->
             <input class="modal-body-input" [(ngModel)]="amend" placeholder="Add modified commit message" type="text">
+            <button type="button" class="btn btn-primary" (click)="amendLastCommit(amend)" data-dismiss="modal">Amend</button>
           </div>
         </div>
         <div class="modal-footer">

--- a/app/components/footer/footer.component.html
+++ b/app/components/footer/footer.component.html
@@ -46,6 +46,7 @@
         <div class="modal-body">
           <div>
             <button type="button" class="btn btn-primary" (click)="amendLastCommit()" data-dismiss="modal">Amend</button>
+            <input class="modal-body-input" ng-model="modifyMessage" placeholder="Add modified commit message" type="text">
           </div>
         </div>
         <div class="modal-footer">

--- a/app/components/footer/footer.component.html
+++ b/app/components/footer/footer.component.html
@@ -45,8 +45,9 @@
         </div>
         <div class="modal-body">
           <div>
-            <button type="button" class="btn btn-primary" (click)="amendLastCommit()" data-dismiss="modal">Amend</button>
-            <input class="modal-body-input" ng-model="modifyMessage" placeholder="Add modified commit message" type="text">
+            <button type="button" class="btn btn-primary" (click)="amendLastCommit(amend)" data-dismiss="modal">Amend</button>
+            <!-- Here's the input field to add the modified commit message -->
+            <input class="modal-body-input" [(ngModel)]="amend" placeholder="Add modified commit message" type="text">
           </div>
         </div>
         <div class="modal-footer">

--- a/app/components/footer/footer.component.html
+++ b/app/components/footer/footer.component.html
@@ -32,7 +32,7 @@
         </div>
     </div>
 </div>
-<!-- TODO: Modify style of modal and add ability to handle user input-->
+
 <!--Modal for amending the last commit-->
 <div id="amend-commit-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog">

--- a/app/components/footer/footer.component.html
+++ b/app/components/footer/footer.component.html
@@ -10,7 +10,7 @@
             <button class="commit-button" id="commit-button">Commit</button>
             <button class="commit-button" id="fileEdit-button" (click)="displayFileEditor()">File Editor</button>
             <button class="commit-button" id="Issues-button" (click)="displayIssuePanel()">Issues</button>
-            <button class="commit-button" id="amend-commit-button" (click)="amendLastCommit()">Amend Commit</button>
+            <button class="commit-button" id="amend-commit-button" (click)="amendLastCommit()" >Amend Commit</button>
 
         </div>
     </div>

--- a/app/components/footer/footer.component.html
+++ b/app/components/footer/footer.component.html
@@ -10,6 +10,7 @@
             <button class="commit-button" id="commit-button">Commit</button>
             <button class="commit-button" id="fileEdit-button" (click)="displayFileEditor()">File Editor</button>
             <button class="commit-button" id="Issues-button" (click)="displayIssuePanel()">Issues</button>
+            <button class="commit-button" id="amend-commit-button" (click)="amendLastCommit()">Amend Commit</button>
 
         </div>
     </div>

--- a/app/components/footer/footer.component.ts
+++ b/app/components/footer/footer.component.ts
@@ -27,6 +27,6 @@ export class FooterComponent {
   }
 
   async amendLastCommit(): void {
-    await amendLastCommit('TESTING12313');
+    await amendLastCommit(modifyMessage);
   }
 }

--- a/app/components/footer/footer.component.ts
+++ b/app/components/footer/footer.component.ts
@@ -2,7 +2,8 @@ import { Component } from "@angular/core";
 
 @Component({
   selector: "app-footer",
-  templateUrl: 'app/components/footer/footer.component.html'
+  templateUrl: 'app/components/footer/footer.component.html',
+  styleUrls: ['app/components/footer/footer.component.css']
 })
 
 export class FooterComponent {

--- a/app/components/footer/footer.component.ts
+++ b/app/components/footer/footer.component.ts
@@ -26,7 +26,8 @@ export class FooterComponent {
     } 
   }
 
-  async amendLastCommit(): void {
-    await amendLastCommit(modifyMessage);
+/* This function is executed when amend button is clicked */
+  async amendLastCommit(amend): void {
+    await amendLastCommit(amend);
   }
 }

--- a/app/components/footer/footer.component.ts
+++ b/app/components/footer/footer.component.ts
@@ -6,6 +6,7 @@ import { Component } from "@angular/core";
 })
 
 export class FooterComponent {
+
   displayFileEditor(): void {
     let editor = document.getElementById("editor-panel");
 
@@ -23,5 +24,9 @@ export class FooterComponent {
       issue.style.width = "100vw"
       issue.style.zIndex = "10";
     } 
+  }
+
+  async amendLastCommit(): void {
+    await amendLastCommit('TESTING12313');
   }
 }

--- a/app/components/graphPanel/graph.panel.component.html
+++ b/app/components/graphPanel/graph.panel.component.html
@@ -51,7 +51,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <button type="button" id="onExit"class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
           
         </div>
         <div class="modal-body">
@@ -66,23 +66,24 @@
                 <h4>Commit History</h4>
                 <table>
                   <tbody id="commitTagList" *ngIf="showCommitList">
-                    <tr *ngFor="let tag of tagList">
-                      <td><h4>{{tag.commitMsg}}</h4></td>
+                    <tr *ngFor="let commit of commitList">
+                      <td><h4>{{commit.commitMsg}}</h4></td>
                       <td id="tagDiv">
                         <table>
                           <tr>
                             <td>
-                                <button class="btn-sm btn-success">Add</button>
+                              <button *ngIf="commit.hasTag" class="btn-sm btn-warning" (click)="addOrModifyTag(commit)">Modify</button>
+                              <button *ngIf="!commit.hasTag" class="btn-sm btn-success" (click)="addOrModifyTag(commit)">Add</button>
                             </td>
                             <td>
                                 <div>
-                                    <input placeholder="{{tag.tagName}}" class="tag-div-name-input" id="tag-div-name-input"/>
-                                    <input placeholder="{{tag.tagMsg}}" class="tag-div-message-input" id="tag-div-message-input"/>
-                                  </div>
+                                    <input type="text" [(ngModel)]="commit.tagName" placeholder="Add Tag Name" class="tag-div-name-input" id="tag-div-name-input"/>
+                                    <input type="text" [(ngModel)]="commit.tagMsg" placeholder="Add Tag Message" class="tag-div-message-input" id="tag-div-message-input"/>
+                                </div>
 
                             </td>
                             <td>
-                                <button class="btn-sm btn-danger" (click)="deleteTag(tag.tagName)">Delete</button>
+                                <button class="btn-sm btn-danger" (click)="deleteTag(commit.oldTagName)">Delete</button>
                             </td>
                               
                           </tr>

--- a/app/components/graphPanel/graph.panel.component.ts
+++ b/app/components/graphPanel/graph.panel.component.ts
@@ -8,11 +8,11 @@ import { resolve } from "url";
 })
 
 export class GraphPanelComponent {
-  tagList: any;
+  commitList: any;
   showCommitList: boolean;
   @ViewChild('graphNodeClickModal') modal: ElementRef;
   //
-  // Listen for user click on graph and display if node clicked
+  // Listen for user click on graph and display if nodelclicked
   @HostListener('click', ['$event']) 
   async onClick() {
     // Check if modal has show class
@@ -21,17 +21,19 @@ export class GraphPanelComponent {
     if(modal){
       let beginnningHash = document.getElementById('commitHash').innerHTML;
       let numCommit = document.getElementById('numCommit').innerHTML;
-      await this.asyncCall(beginnningHash, numCommit);
+      await this.asyncGetCommits(beginnningHash, numCommit);
       this.showCommitList = true;
     }
     // remove if show class
     document.getElementById("graphNodeClickModal").classList.remove('loadTags');
   }
+
   
   // get all tags and commits information
-  async asyncCall(beginnningHash, endingHash) {
-    this.tagList = await getTags(beginnningHash, endingHash);
+  async asyncGetCommits(beginnningHash, endingHash) {
+    this.commitList = await getTags(beginnningHash, endingHash);
   }
+
 
   mergeBranches(): void {
     let p1 = document.getElementById('fromMerge').innerHTML;
@@ -45,12 +47,15 @@ export class GraphPanelComponent {
   }
 
   // Delete tag when delete tag button is clicked. Method will reload list of commits after tag has been deleted
-  deleteTag(tagName): void {
-    deleteTag(tagName);
-    let beginnningHash = document.getElementById('commitHash').innerHTML;
-    let numCommit = document.getElementById('numCommit').innerHTML;
-    this.asyncCall(beginnningHash, numCommit);
+  async deleteTag(tagName): void {
+    await deleteTag(tagName);
+    document.getElementById("onExit").click();
     //this.modal.nativeElement.contentWindow.location.reload(true);
+  }
+
+  async addOrModifyTag(commit): void {
+    await addOrModifyTag(commit);
+    document.getElementById("onExit").click();
   }
 
 

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -1933,8 +1933,12 @@ async function amendLastCommit(newMessage: string) {
     tree = await lastCommit.getTree();
     treeOid = tree.id();
     lastCommitOid = lastCommit.id();
-
-    await lastCommit.amend("HEAD", signature, signature, newMessage, newMessage, treeOid, lastCommitOid);
+    
+    // Amend the last local commit with the new message
+    await lastCommit.amend("HEAD", signature, signature, newMessage, newMessage, treeOid, lastCommitOid)
+      .then(() => {
+        refreshAll(repos);
+      });
     addCommand("git commit --amend -m " + '"' + newMessage + '"');
   } catch (error) {
     console.log(error);

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -382,7 +382,6 @@ function sortedListOfCommits(commits){
   }
 
 }
-//test
 
 function cloneFromRemote() {
   switchToClonePanel();

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -1908,6 +1908,39 @@ async function checkIfExistLocalCommit() {
   }
 
 }
+
+// Method takes the new commit message and amends the last commit in the current branch
+async function amendLastCommit(newMessage: string) {
+  let repo;
+  let revwalk;
+  let commitArray;
+  let lastCommit;
+  let lastCommitOid;
+  let signature;
+  let tree;
+  let treeOid;
+
+  repo = await Git.Repository.open(repoFullPath);
+  revwalk = Git.Revwalk.create(repo);
+  // Points revwalk to last commit
+  revwalk.pushHead();
+  // Get the last commit
+  commitArray = await revwalk.getCommits(1);
+  lastCommit = commitArray[0];
+
+  try {
+    signature = repo.defaultSignature();
+    tree = await lastCommit.getTree();
+    treeOid = tree.id();
+    lastCommitOid = lastCommit.id();
+
+    await lastCommit.amend("HEAD", signature, signature, newMessage, newMessage, treeOid, lastCommitOid);
+  } catch (error) {
+    console.log(error);
+    window.alert('Unable to amend last commit');
+  }
+}
+
 function revertCommit() {
 
   let repos;

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -252,6 +252,9 @@ function refreshStashHistory(){
     document.getElementById('stash-list').innerHTML = stashListHTML;
   }
 
+function amendCommit() {
+
+}
 
 /* Issue 84: further implement stashing
     - git stash show stash{index} shows the deltas of
@@ -1444,6 +1447,25 @@ function getBranchName() {
         });
     });
 }
+//returns the name of the current branch
+async function clonegetBranchName() {
+  let repo;
+  let currentBranch;
+  let branchName;
+  
+  repo = await Git.Repository.open(repoFullPath);
+  console.log('test1');
+  console.log(repo);
+  currentBranch = await repo.getCurrentBranch();
+  console.log('test2');
+  console.log(currentBranch);
+  branchName = await Branch.name(currentBranch);
+  console.log(branchName);
+  console.log('test3');
+  return new Promise(resolve=> {
+    resolve(branchName);
+  });
+}
 
 
 async function pushToRemote() {
@@ -1838,6 +1860,29 @@ function resetCommit(name: string) {
     });
 }
 
+// Method will return true/false if current branch has one or more local commits
+async function checkIfExistLocalCommit() {
+  let branch;
+  let remoteBranchExist;
+  let aheadBehind;
+  await clonegetBranchName().then((branchName) => {
+    branch = branchName;
+  });
+  
+  remoteBranchExist = await checkIfExistOrigin(branch);
+  // Check if the remote version of current branch exists
+  if (!remoteBranchExist) {
+      return;
+  } 
+
+  aheadBehind = await getAheadBehindCommits(branch);
+  console.log(aheadBehind);
+  // Return true if local branch is ahead
+  if (aheadBehind.ahead > 0) {
+    return true;
+  }
+  
+}
 function revertCommit() {
 
   let repos;

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -1937,7 +1937,7 @@ async function amendLastCommit(newMessage: string) {
     // Amend the last local commit with the new message
     await lastCommit.amend("HEAD", signature, signature, newMessage, newMessage, treeOid, lastCommitOid)
       .then(() => {
-        refreshAll(repos);
+        refreshAll(repo);
       });
     addCommand("git commit --amend -m " + '"' + newMessage + '"');
   } catch (error) {

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -1935,6 +1935,7 @@ async function amendLastCommit(newMessage: string) {
     lastCommitOid = lastCommit.id();
 
     await lastCommit.amend("HEAD", signature, signature, newMessage, newMessage, treeOid, lastCommitOid);
+    addCommand("git commit --amend -m " + '"' + newMessage + '"');
   } catch (error) {
     console.log(error);
     window.alert('Unable to amend last commit');

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -382,6 +382,7 @@ function sortedListOfCommits(commits){
   }
 
 }
+//test
 
 function cloneFromRemote() {
   switchToClonePanel();

--- a/app/misc/repo.ts
+++ b/app/misc/repo.ts
@@ -338,6 +338,7 @@ function openRepository() {
     document.getElementById('spinner').style.display = 'block';
     let branch;
     bname = [];
+    checkAmendButton();
     //Get the current branch from the repo
     repository.getCurrentBranch()
       .then(function (reference) {

--- a/app/misc/router.ts
+++ b/app/misc/router.ts
@@ -136,7 +136,7 @@ function displayClonePanel() {
   $("#open-local-repository").hide();
 }
 
-async function displayFilePanel() {
+function displayFilePanel() {
   let filePanel = document.getElementById("file-panel");
   if (filePanel != null){
     filePanel.style.zIndex = "10";
@@ -165,26 +165,47 @@ async function displayFilePanel() {
   if (fileEditButton != null){
     fileEditButton.style.visibility = "visible";
   }
-  let amendCommitButton = document.getElementById("amend-commit-button");
-  let ahead;
-  console.log('test');
+  checkAmendButton();
+  // let amendCommitButton = document.getElementById("amend-commit-button");
+  // let ahead;
+  // console.log('test');
   
-  ahead = await checkIfExistLocalCommit();
-  console.log('AHEAD', ahead);
-  if (amendCommitButton != null){
-    amendCommitButton.style.visibility = "visible";
-    if (!ahead) {
-      amendCommitButton.style.cursor = "not-allowed";
-      amendCommitButton.style['pointer-events'] = "none";
-    } else {
-      amendCommitButton.style.cursor = "pointer";
-      amendCommitButton.style['pointer-events'] = "auto";
-    }
-  }
+  // ahead = await checkIfExistLocalCommit();
+  // console.log('AHEAD', ahead);
+  // if (amendCommitButton != null){
+  //   amendCommitButton.style.visibility = "visible";
+  //   if (!ahead) {
+  //     amendCommitButton.style.cursor = "not-allowed";
+  //     amendCommitButton.style['pointer-events'] = "none";
+  //   } else {
+  //     amendCommitButton.style.cursor = "pointer";
+  //     amendCommitButton.style['pointer-events'] = "auto";
+  //   }
+  // }
 
   
   
   document.getElementById("Issues-button").style="visiblity: visible";
+}
+
+function checkAmendButton() {
+  // Method checking whether to make amend button clickable. Button will be clickable if there is more than 
+  // one unpushed commit
+  let amendCommitButton = document.getElementById("amend-commit-button");
+  let ahead;
+  checkIfExistLocalCommit().then((ahead) => {
+    console.log('AHEAD', ahead);
+    if (amendCommitButton != null){
+      amendCommitButton.style.visibility = "visible";
+      if (!ahead) {
+        amendCommitButton.style.cursor = "not-allowed";
+        amendCommitButton.style['pointer-events'] = "none";
+      } else {
+        amendCommitButton.style.cursor = "pointer";
+        amendCommitButton.style['pointer-events'] = "auto";
+      }
+    }
+  });
 }
 
 function displayPullRequestPanel() {

--- a/app/misc/router.ts
+++ b/app/misc/router.ts
@@ -3,7 +3,6 @@ let blue = "#39c0ba";
 let gray = "#5b6969";
 let continuedWithoutSignIn = false;
 let inTheApp = false;
-
 let showUsername = true;
 let previousWindow = "repoPanel";
 
@@ -137,7 +136,7 @@ function displayClonePanel() {
   $("#open-local-repository").hide();
 }
 
-function displayFilePanel() {
+async function displayFilePanel() {
   let filePanel = document.getElementById("file-panel");
   if (filePanel != null){
     filePanel.style.zIndex = "10";
@@ -167,19 +166,22 @@ function displayFilePanel() {
     fileEditButton.style.visibility = "visible";
   }
   let amendCommitButton = document.getElementById("amend-commit-button");
-  // checkIfExistLocalCommit().then(function (ahead: boolean) {
-  //   console.log(ahead);
-  //   if (amendCommitButton != null){
-  //     amendCommitButton.style.visibility = "visible";
-  //     if (!ahead) {
-  //       amendCommitButton.style.cursor = "not-allowed";
-  //       amendCommitButton.style['pointer-events'] = "none";
-  //     } else {
-  //       amendCommitButton.style.cursor = "pointer";
-  //       amendCommitButton.style['pointer-events'] = "auto";
-  //     }
-  //   }
-  // });
+  let ahead;
+  console.log('test');
+  
+  ahead = await checkIfExistLocalCommit();
+  console.log('AHEAD', ahead);
+  if (amendCommitButton != null){
+    amendCommitButton.style.visibility = "visible";
+    if (!ahead) {
+      amendCommitButton.style.cursor = "not-allowed";
+      amendCommitButton.style['pointer-events'] = "none";
+    } else {
+      amendCommitButton.style.cursor = "pointer";
+      amendCommitButton.style['pointer-events'] = "auto";
+    }
+  }
+
   
   
   document.getElementById("Issues-button").style="visiblity: visible";

--- a/app/misc/router.ts
+++ b/app/misc/router.ts
@@ -166,6 +166,22 @@ function displayFilePanel() {
   if (fileEditButton != null){
     fileEditButton.style.visibility = "visible";
   }
+  let amendCommitButton = document.getElementById("amend-commit-button");
+  // checkIfExistLocalCommit().then(function (ahead: boolean) {
+  //   console.log(ahead);
+  //   if (amendCommitButton != null){
+  //     amendCommitButton.style.visibility = "visible";
+  //     if (!ahead) {
+  //       amendCommitButton.style.cursor = "not-allowed";
+  //       amendCommitButton.style['pointer-events'] = "none";
+  //     } else {
+  //       amendCommitButton.style.cursor = "pointer";
+  //       amendCommitButton.style['pointer-events'] = "auto";
+  //     }
+  //   }
+  // });
+  
+  
   document.getElementById("Issues-button").style="visiblity: visible";
 }
 
@@ -227,6 +243,11 @@ function hideFilePanel() {
   let fileEditButton = document.getElementById("fileEdit-button");
   if (fileEditButton != null){
     fileEditButton.style.visibility = "hidden";
+  }
+
+  let amendCommitButton = document.getElementById("amend-commit-button");
+  if (amendCommitButton != null){
+    amendCommitButton.style.visibility = "hidden";
   }
 
   document.getElementById("Issues-button").style="visibility: hidden";

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -545,6 +545,12 @@ body .footer .commit-panel .commit-message-input {
   color:rgb(158, 158, 158);
 }
 
+.modal-body-input {
+  border-radius: 3px;
+  padding: 4px;
+  margin: 16px;
+  width: 60%;
+}
 
 body .footer .commit-panel .commit-button-wrapper {
   /* positioned relative to its normal position(bottom left corner) */

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -545,13 +545,6 @@ body .footer .commit-panel .commit-message-input {
   color:rgb(158, 158, 158);
 }
 
-.modal-body-input {
-  border-radius: 3px;
-  padding: 4px;
-  margin: 16px;
-  width: 60%;
-}
-
 body .footer .commit-panel .commit-button-wrapper {
   /* positioned relative to its normal position(bottom left corner) */
   position: relative;


### PR DESCRIPTION
In addition to re-adding the code for #34, this pull request also re-adds the tagging features: display, add, modify, and delete. The tagging feature seemed to have been accidentally deleted by a previous rebase.

User should be able to load the commit modal after clicking on a commit node. 
<img width="876" alt="Screen Shot 2019-06-19 at 9 34 05 PM" src="https://user-images.githubusercontent.com/17919332/59818745-05d6cd80-92da-11e9-97f9-eeb9b0657207.png">
The buttons add, delete, and modify (if tag is already added) should work. 

The amend button at the bottom left of the footer is only clickable if user has one or more un-pushed commits. 